### PR TITLE
Fix CUDA version for the torchvision package

### DIFF
--- a/requirements/frozen.yml
+++ b/requirements/frozen.yml
@@ -157,7 +157,7 @@ dependencies:
     - strict-rfc3339==0.7
     - swagger-spec-validator==2.7.3
     - timm==0.4.5
-    - torchvision==0.9.1
+    - -f https://download.pytorch.org/whl/torch_stable.html torchvision==0.9.1+cu111
     - webcolors==1.11.1
     - websocket-client==0.59.0
     - wrapt==1.12.1


### PR DESCRIPTION
The current setup installs `torchvision` for another CUDA version (10.2 instead of 11.1):

```
Traceback (most recent call last):
  File "***/train.py", line 4, in <module>
    import data_loader.data_loader as module_data
  File "***/data_loader/data_loader.py", line 1, in <module>
    from base import BaseDataLoaderExplicitSplit, BaseMultiDataLoader
  File "***/base/__init__.py", line 2, in <module>
    from .base_dataset import *
  File "***/base/base_dataset.py", line 13, in <module>
    from torchvision import transforms
  File "***/envs/frozen/lib/python3.7/site-packages/torchvision/__init__.py", line 4, in <module>
    from .extension import _HAS_OPS
  File "***/envs/frozen/lib/python3.7/site-packages/torchvision/extension.py", line 101, in <module>
    _check_cuda_version()
  File "***/envs/frozen/lib/python3.7/site-packages/torchvision/extension.py", line 97, in _check_cuda_version
    .format(t_major, t_minor, tv_major, tv_minor))
RuntimeError: Detected that PyTorch and torchvision were compiled with different CUDA versions. PyTorch has CUDA Version=11.1 and torchvision has CUDA Version=10.2. Please reinstall the torchvision that matches your PyTorch install.
```

If you checkout [PyTorch's installation instructions](https://pytorch.org/get-started/locally/), seems like PyPI's version is compiled against CUDA 10.2, so this issue makes sense.

This patch fixes this issue.

I also explored installing `pytorch::torchvision=0.9.1` from Conda but seems like there's a conflict with some of the other installed packages.