### PR TITLE
Fix torchvision version installed

### DIFF
--- a/requirements/frozen.yml
+++ b/requirements/frozen.yml
@@ -123,6 +123,7 @@ dependencies:
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.4.9=haebb681_0
   - pip:
+    - --find-links https://download.pytorch.org/whl/torch_stable.html
     - attrdict==2.0.1
     - attrs==21.2.0
     - bravado==11.0.3
@@ -157,7 +158,7 @@ dependencies:
     - strict-rfc3339==0.7
     - swagger-spec-validator==2.7.3
     - timm==0.4.5
-    - -f https://download.pytorch.org/whl/torch_stable.html torchvision==0.9.1+cu111
+    - torchvision==0.9.1+cu111
     - webcolors==1.11.1
     - websocket-client==0.59.0
     - wrapt==1.12.1


### PR DESCRIPTION
Sorry for the noise, but it seems the fix in #7 isn't enough. For whatever reason, Conda installs a different variant of `torchvision==0.9.1` (e.g., in my case a ROCm one).

Seems like the solution is to specify it as a "global flag" for pip, instead of a local one (see [this SO answer](https://stackoverflow.com/a/60410414/1165181)).

Now it works fine, and MSR-VTT trains fine with this setup (the loss is going down at least...).

Oh, and I also expanded from the short flag `-f` to the long flag `--find-links` so it's clearer what it does.