### PR TITLE
Add support for Decord video reader

### DIFF
--- a/base/base_dataset.py
+++ b/base/base_dataset.py
@@ -2,6 +2,8 @@ import random
 import cv2
 import av
 import os
+
+import decord
 import numpy as np
 import torch
 from PIL import Image, ImageFile
@@ -296,6 +298,19 @@ def read_frames_av(video_path, num_frames, sample='rand', fix_start=None):
     return frames, frame_idxs
 
 
+decord.bridge.set_bridge("torch")
+
+
+def read_frames_decord(video_path, num_frames, sample='rand', fix_start=None):
+    video_reader = decord.VideoReader(video_path, num_threads=1)
+    vlen = len(video_reader)
+    frame_idxs = sample_frames(num_frames, vlen, sample=sample, fix_start=fix_start)
+    frames = video_reader.get_batch(frame_idxs)
+    frames = frames.float() / 255
+    frames = frames.permute(0, 3, 1, 2)
+    return frames, frame_idxs
+
+
 def get_video_len(video_path):
     cap = cv2.VideoCapture(video_path)
     if not (cap.isOpened()):
@@ -307,5 +322,6 @@ def get_video_len(video_path):
 
 video_reader = {
     'av': read_frames_av,
-    'cv2': read_frames_cv2
+    'cv2': read_frames_cv2,
+    'decord': read_frames_decord
 }

--- a/requirements/frozen.yml
+++ b/requirements/frozen.yml
@@ -129,6 +129,7 @@ dependencies:
     - bravado-core==5.17.0
     - colorama==0.4.4
     - cycler==0.10.0
+    - decord==0.6.0
     - dominate==2.6.0
     - einops==0.3.0
     - future==0.18.2


### PR DESCRIPTION
Add support to [Decord](https://github.com/dmlc/decord), a video reader that's [faster than both PyAV and OpenCV](https://github.com/dmlc/decord#preliminary-benchmark) (also for me in practice overall).

On top of being faster in general, this patch only reads the indicated frames indices instead of all, so it should be even faster. I use single-threaded video readers per worker as it should be faster. The rationale is the following. Regardless of how it's doing multithreading, parallelism is usually sublinear or linear in the best case. And if we have multiple serial workers, it should be roughly linear (unless there's an I/O bottleneck). So then the performance should be the same or better. Additionally, we have better control of the number of threads and the workers should compete for them less (having multiple workers with an arbitrary number of threads each makes them compete a lot).

Hopefully, this also fixes #16 and we can use all workers.

Haven't done an end-to-end training run with it but it does train and the code makes sense to make when compared to the other video reader implementations.

PS: good luck with ICCV if you have submitted to it!