### PR TITLE
Assert video file exists

### DIFF
--- a/base/base_dataset.py
+++ b/base/base_dataset.py
@@ -96,10 +96,15 @@ class TextVideoDataset(Dataset):
             fix_start = sample['fix_start']
 
         try:
+            if not os.path.isfile(video_fp):
+                if video_loading == 'strict':
+                    assert False
+                else:
+                    print(f"Warning: missing video file {video_fp}.")
             imgs, idxs = self.video_reader(video_fp, self.video_params['num_frames'], frame_sample, fix_start=fix_start)
-        except:
+        except Exception as e:
             if video_loading == 'strict':
-                raise ValueError(f'Video loading failed for {video_fp}, video loading for this dataset is strict.')
+                raise ValueError(f'Video loading failed for {video_fp}, video loading for this dataset is strict.') from e
             else:
                 imgs = Image.new('RGB', (self.video_params['input_res'], self.video_params['input_res']), (0, 0, 0))
                 imgs = transforms.ToTensor()(imgs).unsqueeze(0)

--- a/base/base_dataset.py
+++ b/base/base_dataset.py
@@ -96,12 +96,11 @@ class TextVideoDataset(Dataset):
             fix_start = sample['fix_start']
 
         try:
-            if not os.path.isfile(video_fp):
-                if video_loading == 'strict':
-                    assert False
-                else:
-                    print(f"Warning: missing video file {video_fp}.")
-            imgs, idxs = self.video_reader(video_fp, self.video_params['num_frames'], frame_sample, fix_start=fix_start)
+            if os.path.isfile(video_fp):
+                imgs, idxs = self.video_reader(video_fp, self.video_params['num_frames'], frame_sample, fix_start=fix_start)
+            else:
+                print(f"Warning: missing video file {video_fp}.")
+                assert False
         except Exception as e:
             if video_loading == 'strict':
                 raise ValueError(f'Video loading failed for {video_fp}, video loading for this dataset is strict.') from e


### PR DESCRIPTION
Check if the video file exists while loading the data. Fail in strict mode, else print a warning.

I think it was silently failing to load all WebVid videos for me when using `cv2`, I realized with `decord`. So I was thinking it's good to warn the user in this case.

Also, I chain the exception in strict mode (`... from e`) so more details are shown in case of failure.