### PR TITLE
Set Decord as default reader in data loader

### DIFF
--- a/data_loader/data_loader.py
+++ b/data_loader/data_loader.py
@@ -16,7 +16,7 @@ def dataset_loader(dataset_name,
                    cut=None,
                    subsample=1,
                    sliding_window_stride=-1,
-                   reader='cv2'):
+                   reader='decord'):
     kwargs = dict(
         dataset_name=dataset_name,
         text_params=text_params,
@@ -66,7 +66,7 @@ class TextVideoDataLoader(BaseDataLoaderExplicitSplit):
                  cut=None,
                  subsample=1,
                  sliding_window_stride=-1,
-                 reader='cv2',
+                 reader='decord',
                  batch_size=1,
                  num_workers=1,
                  shuffle=True):

--- a/model/loss.py
+++ b/model/loss.py
@@ -29,7 +29,7 @@ class MaxMarginRankingLoss(nn.Module):
     def __init__(self, margin=1, fix_norm=True):
         super().__init__()
         self.fix_norm = fix_norm
-        self.loss = th.nn.MarginRankingLoss(margin)
+        self.loss = nn.MarginRankingLoss(margin)
         self.margin = margin
 
     def forward(self, x):


### PR DESCRIPTION
Without this change, the default will still be cv2 when loading configurations.